### PR TITLE
Strictify modules for Webpack compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   },
   "browserify": {
     "transform": [
-      "brfs"
+      "brfs",
+      "strictify"
     ]
   },
   "homepage": "https://github.com/dfcreative/settings-panel#readme",
@@ -64,6 +65,7 @@
     "param-case": "^1.1.2",
     "scope-css": "^1.0.0",
     "simple-color-picker": "0.0.9",
+    "strictify": "^0.2.0",
     "tinycolor2": "^1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Added `'strictify'` transform to include `'use strict';` in every module. For some reason this solves [a problem with eval](https://github.com/facebook/flux/issues/45#issuecomment-54552950) in Webpack dev mode.

After this, `settings-panel` works with [`ify-loader`](https://github.com/hughsk/ify-loader).
